### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "restart_policy": "on_error",
   "description": "Archive old projects on community",
   "docker_image": "supervisely/system:6.73.564",
-  "min_instance_version": "6.8.17",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "categories": ["system"],
   "restart_policy": "on_error",
   "description": "Archive old projects on community",
-  "docker_image": "supervisely/system:6.72.151",
+  "docker_image": "supervisely/system:6.73.564",
   "min_instance_version": "6.8.17",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely==6.72.151
+supervisely==6.73.564
 dropbox==11.36.2


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
